### PR TITLE
Replace stmt deletion with noop assignment. Fixes #17

### DIFF
--- a/mutator/statement/remove_test.go
+++ b/mutator/statement/remove_test.go
@@ -11,6 +11,6 @@ func TestMutatorRemoveStatement(t *testing.T) {
 		t,
 		NewMutatorRemoveStatement(),
 		"../../testdata/statement/remove.go",
-		12,
+		15,
 	)
 }

--- a/testdata/statement/remove.go
+++ b/testdata/statement/remove.go
@@ -2,6 +2,8 @@
 
 package example
 
+import "fmt"
+
 func foo() int {
 	n := 1
 
@@ -35,7 +37,12 @@ func foo() int {
 		n--
 	default:
 		n = 0
+		fmt.Println(n)
+		func() {}()
 	}
+
+	var x = 0
+	x++
 
 	return n
 }

--- a/testdata/statement/remove.go.0.go
+++ b/testdata/statement/remove.go.0.go
@@ -2,6 +2,8 @@
 
 package example
 
+import "fmt"
+
 func foo() int {
 	n := 1
 
@@ -20,6 +22,7 @@ func foo() int {
 	if n < 0 {
 		n = 0
 	}
+	_ = n
 
 	n += bar()
 
@@ -33,7 +36,12 @@ func foo() int {
 		n--
 	default:
 		n = 0
+		fmt.Println(n)
+		func() {}()
 	}
+
+	var x = 0
+	x++
 
 	return n
 }

--- a/testdata/statement/remove.go.1.go
+++ b/testdata/statement/remove.go.1.go
@@ -2,6 +2,8 @@
 
 package example
 
+import "fmt"
+
 func foo() int {
 	n := 1
 
@@ -22,6 +24,7 @@ func foo() int {
 	}
 
 	n++
+	_, _ = n, bar
 
 	bar()
 	bar()
@@ -33,7 +36,12 @@ func foo() int {
 		n--
 	default:
 		n = 0
+		fmt.Println(n)
+		func() {}()
 	}
+
+	var x = 0
+	x++
 
 	return n
 }

--- a/testdata/statement/remove.go.11.go
+++ b/testdata/statement/remove.go.11.go
@@ -2,6 +2,8 @@
 
 package example
 
+import "fmt"
+
 func foo() int {
 	n := 1
 
@@ -32,10 +34,15 @@ func foo() int {
 	case n < 20:
 		n++
 	case n > 20:
-		n--
+		_ = n
 	default:
-
+		n = 0
+		fmt.Println(n)
+		func() {}()
 	}
+
+	var x = 0
+	x++
 
 	return n
 }

--- a/testdata/statement/remove.go.12.go
+++ b/testdata/statement/remove.go.12.go
@@ -32,11 +32,11 @@ func foo() int {
 
 	switch {
 	case n < 20:
-		_ = n
+		n++
 	case n > 20:
 		n--
 	default:
-		n = 0
+		_ = n
 		fmt.Println(n)
 		func() {}()
 	}

--- a/testdata/statement/remove.go.13.go
+++ b/testdata/statement/remove.go.13.go
@@ -32,12 +32,12 @@ func foo() int {
 
 	switch {
 	case n < 20:
-		_ = n
+		n++
 	case n > 20:
 		n--
 	default:
 		n = 0
-		fmt.Println(n)
+		_, _ = fmt.Println, n
 		func() {}()
 	}
 

--- a/testdata/statement/remove.go.14.go
+++ b/testdata/statement/remove.go.14.go
@@ -32,13 +32,13 @@ func foo() int {
 
 	switch {
 	case n < 20:
-		_ = n
+		n++
 	case n > 20:
 		n--
 	default:
 		n = 0
 		fmt.Println(n)
-		func() {}()
+
 	}
 
 	var x = 0

--- a/testdata/statement/remove.go.2.go
+++ b/testdata/statement/remove.go.2.go
@@ -2,6 +2,8 @@
 
 package example
 
+import "fmt"
+
 func foo() int {
 	n := 1
 
@@ -24,7 +26,7 @@ func foo() int {
 	n++
 
 	n += bar()
-
+	_ = bar
 	bar()
 
 	switch {
@@ -34,7 +36,12 @@ func foo() int {
 		n--
 	default:
 		n = 0
+		fmt.Println(n)
+		func() {}()
 	}
+
+	var x = 0
+	x++
 
 	return n
 }

--- a/testdata/statement/remove.go.3.go
+++ b/testdata/statement/remove.go.3.go
@@ -2,6 +2,8 @@
 
 package example
 
+import "fmt"
+
 func foo() int {
 	n := 1
 
@@ -26,6 +28,7 @@ func foo() int {
 	n += bar()
 
 	bar()
+	_ = bar
 
 	switch {
 	case n < 20:
@@ -34,7 +37,12 @@ func foo() int {
 		n--
 	default:
 		n = 0
+		fmt.Println(n)
+		func() {}()
 	}
+
+	var x = 0
+	x++
 
 	return n
 }

--- a/testdata/statement/remove.go.4.go
+++ b/testdata/statement/remove.go.4.go
@@ -2,6 +2,8 @@
 
 package example
 
+import "fmt"
+
 func foo() int {
 	n := 1
 
@@ -14,6 +16,7 @@ func foo() int {
 			n += 3
 		}
 
+		n++
 	}
 
 	if n < 0 {
@@ -34,7 +37,12 @@ func foo() int {
 		n--
 	default:
 		n = 0
+		fmt.Println(n)
+		func() {}()
 	}
+
+	var x = 0
+	_ = x
 
 	return n
 }

--- a/testdata/statement/remove.go.5.go
+++ b/testdata/statement/remove.go.5.go
@@ -2,19 +2,20 @@
 
 package example
 
+import "fmt"
+
 func foo() int {
 	n := 1
 
 	for i := 0; i < 3; i++ {
 		if i == 0 {
-
+			n++
 		} else if i == 1 {
 			n += 2
 		} else {
 			n += 3
 		}
-
-		n++
+		_ = n
 	}
 
 	if n < 0 {
@@ -35,7 +36,12 @@ func foo() int {
 		n--
 	default:
 		n = 0
+		fmt.Println(n)
+		func() {}()
 	}
+
+	var x = 0
+	x++
 
 	return n
 }

--- a/testdata/statement/remove.go.6.go
+++ b/testdata/statement/remove.go.6.go
@@ -2,14 +2,16 @@
 
 package example
 
+import "fmt"
+
 func foo() int {
 	n := 1
 
 	for i := 0; i < 3; i++ {
 		if i == 0 {
-			n++
+			_ = n
 		} else if i == 1 {
-
+			n += 2
 		} else {
 			n += 3
 		}
@@ -35,7 +37,12 @@ func foo() int {
 		n--
 	default:
 		n = 0
+		fmt.Println(n)
+		func() {}()
 	}
+
+	var x = 0
+	x++
 
 	return n
 }

--- a/testdata/statement/remove.go.7.go
+++ b/testdata/statement/remove.go.7.go
@@ -2,6 +2,8 @@
 
 package example
 
+import "fmt"
+
 func foo() int {
 	n := 1
 
@@ -9,9 +11,9 @@ func foo() int {
 		if i == 0 {
 			n++
 		} else if i == 1 {
-			n += 2
+			_ = n
 		} else {
-
+			n += 3
 		}
 
 		n++
@@ -35,7 +37,12 @@ func foo() int {
 		n--
 	default:
 		n = 0
+		fmt.Println(n)
+		func() {}()
 	}
+
+	var x = 0
+	x++
 
 	return n
 }

--- a/testdata/statement/remove.go.8.go
+++ b/testdata/statement/remove.go.8.go
@@ -2,6 +2,8 @@
 
 package example
 
+import "fmt"
+
 func foo() int {
 	n := 1
 
@@ -11,14 +13,14 @@ func foo() int {
 		} else if i == 1 {
 			n += 2
 		} else {
-			n += 3
+			_ = n
 		}
 
 		n++
 	}
 
 	if n < 0 {
-
+		n = 0
 	}
 
 	n++
@@ -35,7 +37,12 @@ func foo() int {
 		n--
 	default:
 		n = 0
+		fmt.Println(n)
+		func() {}()
 	}
+
+	var x = 0
+	x++
 
 	return n
 }

--- a/testdata/statement/remove.go.9.go
+++ b/testdata/statement/remove.go.9.go
@@ -2,6 +2,8 @@
 
 package example
 
+import "fmt"
+
 func foo() int {
 	n := 1
 
@@ -18,7 +20,7 @@ func foo() int {
 	}
 
 	if n < 0 {
-		n = 0
+		_ = n
 	}
 
 	n++
@@ -30,12 +32,17 @@ func foo() int {
 
 	switch {
 	case n < 20:
-
+		n++
 	case n > 20:
 		n--
 	default:
 		n = 0
+		fmt.Println(n)
+		func() {}()
 	}
+
+	var x = 0
+	x++
 
 	return n
 }


### PR DESCRIPTION
This patch changes the statement mutator to replace statements with no-op assignments instead of just deleting them. For example:

```
for i, x := range a {
    doSomething(i, x)
}
```
Used to be mutated into this:
```
for i, x := range a {
}
```
Which does not compile. Now it is mutated into this:
```
for i, x := range a {
    _, _ = i, x
}
```

This way it will compile but will have the same effect as deleting the line. 