### PR TITLE
Do type-checking for perfect statement elimination, and add duplicates to the cmd statistic

### DIFF
--- a/astutil/create.go
+++ b/astutil/create.go
@@ -3,18 +3,19 @@ package astutil
 import (
 	"go/ast"
 	"go/token"
+	"go/types"
 )
 
 // CreateNoopOfStatement creates a syntactically safe noop statement out of a given statement.
-func CreateNoopOfStatement(stmt ast.Stmt) ast.Stmt {
-	return CreateNoopOfStatements([]ast.Stmt{stmt})
+func CreateNoopOfStatement(pkg *types.Package, info *types.Info, stmt ast.Stmt) ast.Stmt {
+	return CreateNoopOfStatements(pkg, info, []ast.Stmt{stmt})
 }
 
 // CreateNoopOfStatements creates a syntactically safe noop statement out of a given statement.
-func CreateNoopOfStatements(stmts []ast.Stmt) ast.Stmt {
+func CreateNoopOfStatements(pkg *types.Package, info *types.Info, stmts []ast.Stmt) ast.Stmt {
 	var ids []ast.Expr
 	for _, stmt := range stmts {
-		ids = append(ids, IdentifiersInStatement(stmt)...)
+		ids = append(ids, IdentifiersInStatement(pkg, info, stmt)...)
 	}
 
 	if len(ids) == 0 {

--- a/cmd/go-mutesting/main.go
+++ b/cmd/go-mutesting/main.go
@@ -144,9 +144,10 @@ type mutatorItem struct {
 }
 
 type mutationStats struct {
-	passed  int
-	failed  int
-	skipped int
+	passed     int
+	failed     int
+	duplicated int
+	skipped    int
 }
 
 func mainCmd(args []string) int {
@@ -291,7 +292,7 @@ MUTATOR:
 	}
 
 	if !opts.Exec.NoExec {
-		fmt.Printf("The mutation score is %f (%d passed, %d failed, %d skipped, total is %d)\n", float64(stats.passed)/float64(stats.passed+stats.failed), stats.passed, stats.failed, stats.skipped, stats.passed+stats.failed+stats.skipped)
+		fmt.Printf("The mutation score is %f (%d passed, %d failed, %d duplicated, %d skipped, total is %d)\n", float64(stats.passed)/float64(stats.passed+stats.failed), stats.passed, stats.failed, stats.duplicated, stats.skipped, stats.passed+stats.failed+stats.duplicated+stats.skipped)
 	} else {
 		fmt.Println("Cannot do a mutation testing summary since no exec command was executed.")
 	}
@@ -329,6 +330,8 @@ func mutate(opts *options, mutators []mutatorItem, mutationBlackList map[string]
 			}
 			if duplicate {
 				debug(opts, "%q is a duplicate, we ignore it", mutationFile)
+
+				stats.duplicated++
 			} else {
 				debug(opts, "Save mutation into %q with checksum %s", mutationFile, checksum)
 

--- a/cmd/go-mutesting/main_test.go
+++ b/cmd/go-mutesting/main_test.go
@@ -15,7 +15,7 @@ func TestMain(t *testing.T) {
 		"../../example",
 		[]string{"--debug", "--exec-timeout", "1"},
 		returnOk,
-		"The mutation score is 0.500000 (7 passed, 7 failed, 8 duplicated, 0 skipped, total is 22)",
+		"The mutation score is 0.538462 (7 passed, 6 failed, 9 duplicated, 0 skipped, total is 22)",
 	)
 }
 
@@ -25,7 +25,7 @@ func TestMainRecursive(t *testing.T) {
 		"../../example",
 		[]string{"--debug", "--exec-timeout", "1", "./..."},
 		returnOk,
-		"The mutation score is 0.533333 (8 passed, 7 failed, 8 duplicated, 0 skipped, total is 23)",
+		"The mutation score is 0.571429 (8 passed, 6 failed, 9 duplicated, 0 skipped, total is 23)",
 	)
 }
 
@@ -35,7 +35,7 @@ func TestMainFromOtherDirectory(t *testing.T) {
 		"../..",
 		[]string{"--debug", "--exec-timeout", "1", "github.com/zimmski/go-mutesting/example"},
 		returnOk,
-		"The mutation score is 0.500000 (7 passed, 7 failed, 8 duplicated, 0 skipped, total is 22)",
+		"The mutation score is 0.538462 (7 passed, 6 failed, 9 duplicated, 0 skipped, total is 22)",
 	)
 }
 

--- a/cmd/go-mutesting/main_test.go
+++ b/cmd/go-mutesting/main_test.go
@@ -15,7 +15,7 @@ func TestMain(t *testing.T) {
 		"../../example",
 		[]string{"--debug", "--exec-timeout", "1"},
 		returnOk,
-		"The mutation score is 0.500000 (7 passed, 7 failed, 0 skipped, total is 14)",
+		"The mutation score is 0.500000 (7 passed, 7 failed, 8 duplicated, 0 skipped, total is 22)",
 	)
 }
 
@@ -25,7 +25,7 @@ func TestMainRecursive(t *testing.T) {
 		"../../example",
 		[]string{"--debug", "--exec-timeout", "1", "./..."},
 		returnOk,
-		"The mutation score is 0.533333 (8 passed, 7 failed, 0 skipped, total is 15)",
+		"The mutation score is 0.533333 (8 passed, 7 failed, 8 duplicated, 0 skipped, total is 23)",
 	)
 }
 
@@ -35,7 +35,7 @@ func TestMainFromOtherDirectory(t *testing.T) {
 		"../..",
 		[]string{"--debug", "--exec-timeout", "1", "github.com/zimmski/go-mutesting/example"},
 		returnOk,
-		"The mutation score is 0.500000 (7 passed, 7 failed, 0 skipped, total is 14)",
+		"The mutation score is 0.500000 (7 passed, 7 failed, 8 duplicated, 0 skipped, total is 22)",
 	)
 }
 
@@ -45,7 +45,7 @@ func TestMainMatch(t *testing.T) {
 		"../../example",
 		[]string{"--debug", "--exec", "../scripts/exec/test-mutated-package.sh", "--exec-timeout", "1", "--match", "baz", "./..."},
 		returnOk,
-		"The mutation score is 0.500000 (1 passed, 1 failed, 0 skipped, total is 2)",
+		"The mutation score is 0.500000 (1 passed, 1 failed, 0 duplicated, 0 skipped, total is 2)",
 	)
 }
 

--- a/mutator/branch/mutatecase.go
+++ b/mutator/branch/mutatecase.go
@@ -2,6 +2,7 @@ package branch
 
 import (
 	"go/ast"
+	"go/types"
 
 	"github.com/zimmski/go-mutesting/astutil"
 	"github.com/zimmski/go-mutesting/mutator"
@@ -12,7 +13,7 @@ func init() {
 }
 
 // MutatorCase implements a mutator for case clauses.
-func MutatorCase(node ast.Node) []mutator.Mutation {
+func MutatorCase(pkg *types.Package, info *types.Info, node ast.Node) []mutator.Mutation {
 	n, ok := node.(*ast.CaseClause)
 	if !ok {
 		return nil
@@ -24,7 +25,7 @@ func MutatorCase(node ast.Node) []mutator.Mutation {
 		mutator.Mutation{
 			Change: func() {
 				n.Body = []ast.Stmt{
-					astutil.CreateNoopOfStatements(n.Body),
+					astutil.CreateNoopOfStatements(pkg, info, n.Body),
 				}
 			},
 			Reset: func() {

--- a/mutator/branch/mutateelse.go
+++ b/mutator/branch/mutateelse.go
@@ -2,6 +2,7 @@ package branch
 
 import (
 	"go/ast"
+	"go/types"
 
 	"github.com/zimmski/go-mutesting/astutil"
 	"github.com/zimmski/go-mutesting/mutator"
@@ -12,7 +13,7 @@ func init() {
 }
 
 // MutatorElse implements a mutator for else branches.
-func MutatorElse(node ast.Node) []mutator.Mutation {
+func MutatorElse(pkg *types.Package, info *types.Info, node ast.Node) []mutator.Mutation {
 	n, ok := node.(*ast.IfStmt)
 	if !ok {
 		return nil
@@ -28,7 +29,7 @@ func MutatorElse(node ast.Node) []mutator.Mutation {
 	return []mutator.Mutation{
 		mutator.Mutation{
 			Change: func() {
-				n.Else = astutil.CreateNoopOfStatement(old)
+				n.Else = astutil.CreateNoopOfStatement(pkg, info, old)
 			},
 			Reset: func() {
 				n.Else = old

--- a/mutator/branch/mutateif.go
+++ b/mutator/branch/mutateif.go
@@ -2,6 +2,7 @@ package branch
 
 import (
 	"go/ast"
+	"go/types"
 
 	"github.com/zimmski/go-mutesting/astutil"
 	"github.com/zimmski/go-mutesting/mutator"
@@ -12,7 +13,7 @@ func init() {
 }
 
 // MutatorIf implements a mutator for if and else if branches.
-func MutatorIf(node ast.Node) []mutator.Mutation {
+func MutatorIf(pkg *types.Package, info *types.Info, node ast.Node) []mutator.Mutation {
 	n, ok := node.(*ast.IfStmt)
 	if !ok {
 		return nil
@@ -24,7 +25,7 @@ func MutatorIf(node ast.Node) []mutator.Mutation {
 		mutator.Mutation{
 			Change: func() {
 				n.Body.List = []ast.Stmt{
-					astutil.CreateNoopOfStatement(n.Body),
+					astutil.CreateNoopOfStatement(pkg, info, n.Body),
 				}
 			},
 			Reset: func() {

--- a/mutator/expression/remove.go
+++ b/mutator/expression/remove.go
@@ -3,6 +3,7 @@ package expression
 import (
 	"go/ast"
 	"go/token"
+	"go/types"
 
 	"github.com/zimmski/go-mutesting/mutator"
 )
@@ -12,7 +13,7 @@ func init() {
 }
 
 // MutatorRemoveTerm implements a mutator to remove expression terms.
-func MutatorRemoveTerm(node ast.Node) []mutator.Mutation {
+func MutatorRemoveTerm(pkg *types.Package, info *types.Info, node ast.Node) []mutator.Mutation {
 	n, ok := node.(*ast.BinaryExpr)
 	if !ok {
 		return nil

--- a/mutator/mutator.go
+++ b/mutator/mutator.go
@@ -3,11 +3,12 @@ package mutator
 import (
 	"fmt"
 	"go/ast"
+	"go/types"
 	"sort"
 )
 
 // Mutator defines a mutator for mutation testing by returning a list of possible mutations for the given node.
-type Mutator func(node ast.Node) []Mutation
+type Mutator func(pkg *types.Package, info *types.Info, node ast.Node) []Mutation
 
 var mutatorLookup = make(map[string]Mutator)
 

--- a/mutator/mutator_test.go
+++ b/mutator/mutator_test.go
@@ -2,12 +2,13 @@ package mutator
 
 import (
 	"go/ast"
+	"go/types"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func mockMutator(node ast.Node) []Mutation {
+func mockMutator(pkg *types.Package, info *types.Info, node ast.Node) []Mutation {
 	// Do nothing
 
 	return nil

--- a/mutator/statement/remove.go
+++ b/mutator/statement/remove.go
@@ -3,6 +3,7 @@ package statement
 import (
 	"go/ast"
 	"go/token"
+	"go/types"
 
 	"github.com/zimmski/go-mutesting/astutil"
 	"github.com/zimmski/go-mutesting/mutator"
@@ -26,7 +27,7 @@ func checkRemoveStatement(node ast.Stmt) bool {
 }
 
 // MutatorRemoveStatement implements a mutator to remove statements.
-func MutatorRemoveStatement(node ast.Node) []mutator.Mutation {
+func MutatorRemoveStatement(pkg *types.Package, info *types.Info, node ast.Node) []mutator.Mutation {
 	var l []ast.Stmt
 
 	switch n := node.(type) {
@@ -45,7 +46,7 @@ func MutatorRemoveStatement(node ast.Node) []mutator.Mutation {
 
 			mutations = append(mutations, mutator.Mutation{
 				Change: func() {
-					l[li] = astutil.CreateNoopOfStatement(old)
+					l[li] = astutil.CreateNoopOfStatement(pkg, info, old)
 				},
 				Reset: func() {
 					l[li] = old

--- a/mutator/statement/remove_test.go
+++ b/mutator/statement/remove_test.go
@@ -11,6 +11,6 @@ func TestMutatorRemoveStatement(t *testing.T) {
 		t,
 		MutatorRemoveStatement,
 		"../../testdata/statement/remove.go",
-		15,
+		17,
 	)
 }

--- a/testdata/statement/remove.go
+++ b/testdata/statement/remove.go
@@ -2,7 +2,10 @@
 
 package example
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
 func foo() int {
 	n := 1
@@ -49,4 +52,21 @@ func foo() int {
 
 func bar() int {
 	return 4
+}
+
+func statementRemoveStructInitialization() (a http.Header, b error) {
+	var err error
+
+	a, b = http.Header{}, err
+
+	return
+}
+
+func statementRemoveStringArrayMap() map[string][]string {
+	hash := "ok"
+	var hdr = make(map[string][]string)
+
+	hdr["Hash"] = []string{hash}
+
+	return hdr
 }

--- a/testdata/statement/remove.go.0.go
+++ b/testdata/statement/remove.go.0.go
@@ -2,7 +2,10 @@
 
 package example
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
 func foo() int {
 	n := 1
@@ -48,4 +51,21 @@ func foo() int {
 
 func bar() int {
 	return 4
+}
+
+func statementRemoveStructInitialization() (a http.Header, b error) {
+	var err error
+
+	a, b = http.Header{}, err
+
+	return
+}
+
+func statementRemoveStringArrayMap() map[string][]string {
+	hash := "ok"
+	var hdr = make(map[string][]string)
+
+	hdr["Hash"] = []string{hash}
+
+	return hdr
 }

--- a/testdata/statement/remove.go.1.go
+++ b/testdata/statement/remove.go.1.go
@@ -2,7 +2,10 @@
 
 package example
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
 func foo() int {
 	n := 1
@@ -48,4 +51,21 @@ func foo() int {
 
 func bar() int {
 	return 4
+}
+
+func statementRemoveStructInitialization() (a http.Header, b error) {
+	var err error
+
+	a, b = http.Header{}, err
+
+	return
+}
+
+func statementRemoveStringArrayMap() map[string][]string {
+	hash := "ok"
+	var hdr = make(map[string][]string)
+
+	hdr["Hash"] = []string{hash}
+
+	return hdr
 }

--- a/testdata/statement/remove.go.1.go
+++ b/testdata/statement/remove.go.1.go
@@ -27,7 +27,7 @@ func foo() int {
 	}
 
 	n++
-	_, _ = n, bar
+	_ = n
 
 	bar()
 	bar()

--- a/testdata/statement/remove.go.11.go
+++ b/testdata/statement/remove.go.11.go
@@ -2,7 +2,10 @@
 
 package example
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
 func foo() int {
 	n := 1
@@ -49,4 +52,21 @@ func foo() int {
 
 func bar() int {
 	return 4
+}
+
+func statementRemoveStructInitialization() (a http.Header, b error) {
+	var err error
+
+	a, b = http.Header{}, err
+
+	return
+}
+
+func statementRemoveStringArrayMap() map[string][]string {
+	hash := "ok"
+	var hdr = make(map[string][]string)
+
+	hdr["Hash"] = []string{hash}
+
+	return hdr
 }

--- a/testdata/statement/remove.go.12.go
+++ b/testdata/statement/remove.go.12.go
@@ -2,7 +2,10 @@
 
 package example
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
 func foo() int {
 	n := 1
@@ -49,4 +52,21 @@ func foo() int {
 
 func bar() int {
 	return 4
+}
+
+func statementRemoveStructInitialization() (a http.Header, b error) {
+	var err error
+
+	a, b = http.Header{}, err
+
+	return
+}
+
+func statementRemoveStringArrayMap() map[string][]string {
+	hash := "ok"
+	var hdr = make(map[string][]string)
+
+	hdr["Hash"] = []string{hash}
+
+	return hdr
 }

--- a/testdata/statement/remove.go.13.go
+++ b/testdata/statement/remove.go.13.go
@@ -2,7 +2,10 @@
 
 package example
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
 func foo() int {
 	n := 1
@@ -49,4 +52,21 @@ func foo() int {
 
 func bar() int {
 	return 4
+}
+
+func statementRemoveStructInitialization() (a http.Header, b error) {
+	var err error
+
+	a, b = http.Header{}, err
+
+	return
+}
+
+func statementRemoveStringArrayMap() map[string][]string {
+	hash := "ok"
+	var hdr = make(map[string][]string)
+
+	hdr["Hash"] = []string{hash}
+
+	return hdr
 }

--- a/testdata/statement/remove.go.14.go
+++ b/testdata/statement/remove.go.14.go
@@ -2,7 +2,10 @@
 
 package example
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
 func foo() int {
 	n := 1
@@ -49,4 +52,21 @@ func foo() int {
 
 func bar() int {
 	return 4
+}
+
+func statementRemoveStructInitialization() (a http.Header, b error) {
+	var err error
+
+	a, b = http.Header{}, err
+
+	return
+}
+
+func statementRemoveStringArrayMap() map[string][]string {
+	hash := "ok"
+	var hdr = make(map[string][]string)
+
+	hdr["Hash"] = []string{hash}
+
+	return hdr
 }

--- a/testdata/statement/remove.go.15.go
+++ b/testdata/statement/remove.go.15.go
@@ -56,7 +56,7 @@ func bar() int {
 
 func statementRemoveStructInitialization() (a http.Header, b error) {
 	var err error
-	_, _, _, _ = a, b, http.Header, err
+	_, _, _, _ = a, b, http.Header{}, err
 
 	return
 }

--- a/testdata/statement/remove.go.15.go
+++ b/testdata/statement/remove.go.15.go
@@ -35,7 +35,7 @@ func foo() int {
 
 	switch {
 	case n < 20:
-		_ = n
+		n++
 	case n > 20:
 		n--
 	default:
@@ -56,8 +56,7 @@ func bar() int {
 
 func statementRemoveStructInitialization() (a http.Header, b error) {
 	var err error
-
-	a, b = http.Header{}, err
+	_, _, _, _ = a, b, http.Header, err
 
 	return
 }

--- a/testdata/statement/remove.go.16.go
+++ b/testdata/statement/remove.go.16.go
@@ -35,7 +35,7 @@ func foo() int {
 
 	switch {
 	case n < 20:
-		_ = n
+		n++
 	case n > 20:
 		n--
 	default:
@@ -65,8 +65,7 @@ func statementRemoveStructInitialization() (a http.Header, b error) {
 func statementRemoveStringArrayMap() map[string][]string {
 	hash := "ok"
 	var hdr = make(map[string][]string)
-
-	hdr["Hash"] = []string{hash}
+	_, _ = hdr, hash
 
 	return hdr
 }

--- a/testdata/statement/remove.go.2.go
+++ b/testdata/statement/remove.go.2.go
@@ -2,7 +2,10 @@
 
 package example
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
 func foo() int {
 	n := 1
@@ -48,4 +51,21 @@ func foo() int {
 
 func bar() int {
 	return 4
+}
+
+func statementRemoveStructInitialization() (a http.Header, b error) {
+	var err error
+
+	a, b = http.Header{}, err
+
+	return
+}
+
+func statementRemoveStringArrayMap() map[string][]string {
+	hash := "ok"
+	var hdr = make(map[string][]string)
+
+	hdr["Hash"] = []string{hash}
+
+	return hdr
 }

--- a/testdata/statement/remove.go.2.go
+++ b/testdata/statement/remove.go.2.go
@@ -29,7 +29,7 @@ func foo() int {
 	n++
 
 	n += bar()
-	_ = bar
+
 	bar()
 
 	switch {

--- a/testdata/statement/remove.go.3.go
+++ b/testdata/statement/remove.go.3.go
@@ -2,7 +2,10 @@
 
 package example
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
 func foo() int {
 	n := 1
@@ -49,4 +52,21 @@ func foo() int {
 
 func bar() int {
 	return 4
+}
+
+func statementRemoveStructInitialization() (a http.Header, b error) {
+	var err error
+
+	a, b = http.Header{}, err
+
+	return
+}
+
+func statementRemoveStringArrayMap() map[string][]string {
+	hash := "ok"
+	var hdr = make(map[string][]string)
+
+	hdr["Hash"] = []string{hash}
+
+	return hdr
 }

--- a/testdata/statement/remove.go.3.go
+++ b/testdata/statement/remove.go.3.go
@@ -31,7 +31,6 @@ func foo() int {
 	n += bar()
 
 	bar()
-	_ = bar
 
 	switch {
 	case n < 20:

--- a/testdata/statement/remove.go.4.go
+++ b/testdata/statement/remove.go.4.go
@@ -2,7 +2,10 @@
 
 package example
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
 func foo() int {
 	n := 1
@@ -49,4 +52,21 @@ func foo() int {
 
 func bar() int {
 	return 4
+}
+
+func statementRemoveStructInitialization() (a http.Header, b error) {
+	var err error
+
+	a, b = http.Header{}, err
+
+	return
+}
+
+func statementRemoveStringArrayMap() map[string][]string {
+	hash := "ok"
+	var hdr = make(map[string][]string)
+
+	hdr["Hash"] = []string{hash}
+
+	return hdr
 }

--- a/testdata/statement/remove.go.5.go
+++ b/testdata/statement/remove.go.5.go
@@ -2,7 +2,10 @@
 
 package example
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
 func foo() int {
 	n := 1
@@ -48,4 +51,21 @@ func foo() int {
 
 func bar() int {
 	return 4
+}
+
+func statementRemoveStructInitialization() (a http.Header, b error) {
+	var err error
+
+	a, b = http.Header{}, err
+
+	return
+}
+
+func statementRemoveStringArrayMap() map[string][]string {
+	hash := "ok"
+	var hdr = make(map[string][]string)
+
+	hdr["Hash"] = []string{hash}
+
+	return hdr
 }

--- a/testdata/statement/remove.go.6.go
+++ b/testdata/statement/remove.go.6.go
@@ -2,7 +2,10 @@
 
 package example
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
 func foo() int {
 	n := 1
@@ -49,4 +52,21 @@ func foo() int {
 
 func bar() int {
 	return 4
+}
+
+func statementRemoveStructInitialization() (a http.Header, b error) {
+	var err error
+
+	a, b = http.Header{}, err
+
+	return
+}
+
+func statementRemoveStringArrayMap() map[string][]string {
+	hash := "ok"
+	var hdr = make(map[string][]string)
+
+	hdr["Hash"] = []string{hash}
+
+	return hdr
 }

--- a/testdata/statement/remove.go.7.go
+++ b/testdata/statement/remove.go.7.go
@@ -2,7 +2,10 @@
 
 package example
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
 func foo() int {
 	n := 1
@@ -49,4 +52,21 @@ func foo() int {
 
 func bar() int {
 	return 4
+}
+
+func statementRemoveStructInitialization() (a http.Header, b error) {
+	var err error
+
+	a, b = http.Header{}, err
+
+	return
+}
+
+func statementRemoveStringArrayMap() map[string][]string {
+	hash := "ok"
+	var hdr = make(map[string][]string)
+
+	hdr["Hash"] = []string{hash}
+
+	return hdr
 }

--- a/testdata/statement/remove.go.8.go
+++ b/testdata/statement/remove.go.8.go
@@ -2,7 +2,10 @@
 
 package example
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
 func foo() int {
 	n := 1
@@ -49,4 +52,21 @@ func foo() int {
 
 func bar() int {
 	return 4
+}
+
+func statementRemoveStructInitialization() (a http.Header, b error) {
+	var err error
+
+	a, b = http.Header{}, err
+
+	return
+}
+
+func statementRemoveStringArrayMap() map[string][]string {
+	hash := "ok"
+	var hdr = make(map[string][]string)
+
+	hdr["Hash"] = []string{hash}
+
+	return hdr
 }

--- a/testdata/statement/remove.go.9.go
+++ b/testdata/statement/remove.go.9.go
@@ -2,7 +2,10 @@
 
 package example
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
 func foo() int {
 	n := 1
@@ -49,4 +52,21 @@ func foo() int {
 
 func bar() int {
 	return 4
+}
+
+func statementRemoveStructInitialization() (a http.Header, b error) {
+	var err error
+
+	a, b = http.Header{}, err
+
+	return
+}
+
+func statementRemoveStringArrayMap() map[string][]string {
+	hash := "ok"
+	var hdr = make(map[string][]string)
+
+	hdr["Hash"] = []string{hash}
+
+	return hdr
 }


### PR DESCRIPTION
The API changes might not be needed for the mutators but I do not know how to forward the package information otherwise. Also, maybe the "info" object is not needed at all but that might be a good PR for another one.