### PR TITLE
Only count skipped not duplicates mutations towards the total count

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 
 script:
   - make lint
-  - make test-with-coverage
+  - make test-verbose-with-coverage
   - gover
   - if [ "$TRAVIS_SECURE_ENV_VARS" = "true" ]; then goveralls -coverprofile=gover.coverprofile -service=travis-ci -repotoken $COVERALLS_TOKEN; fi
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean clean-coverage generate install install-dependencies install-tools lint test test-verbose test-with-coverage
+.PHONY: all clean clean-coverage generate install install-dependencies install-tools lint test test-verbose test-verbose-with-coverage
 
 export ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 export PKG := github.com/zimmski/go-mutesting
@@ -46,5 +46,5 @@ test:
 	go test -race -test.timeout 120s $(PKG_TEST)
 test-verbose:
 	go test -race -test.timeout 120s -v $(PKG_TEST)
-test-with-coverage:
-	ginkgo -r -cover -race -skipPackage="testdata"
+test-verbose-with-coverage:
+	ginkgo -r -v -cover -race -skipPackage="testdata"

--- a/cmd/go-mutesting/main.go
+++ b/cmd/go-mutesting/main.go
@@ -152,6 +152,20 @@ type mutationStats struct {
 	skipped    int
 }
 
+func (ms *mutationStats) Score() float64 {
+	total := ms.Total()
+
+	if total == 0 {
+		return 0.0
+	}
+
+	return float64(ms.passed) / float64(total)
+}
+
+func (ms *mutationStats) Total() int {
+	return ms.passed + ms.failed + ms.skipped
+}
+
 func mainCmd(args []string) int {
 	var opts = &options{}
 	var mutationBlackList = map[string]struct{}{}
@@ -317,7 +331,7 @@ MUTATOR:
 	}
 
 	if !opts.Exec.NoExec {
-		fmt.Printf("The mutation score is %f (%d passed, %d failed, %d duplicated, %d skipped, total is %d)\n", float64(stats.passed)/float64(stats.passed+stats.failed), stats.passed, stats.failed, stats.duplicated, stats.skipped, stats.passed+stats.failed+stats.duplicated+stats.skipped)
+		fmt.Printf("The mutation score is %f (%d passed, %d failed, %d duplicated, %d skipped, total is %d)\n", stats.Score(), stats.passed, stats.failed, stats.duplicated, stats.skipped, stats.Total())
 	} else {
 		fmt.Println("Cannot do a mutation testing summary since no exec command was executed.")
 	}

--- a/cmd/go-mutesting/main_test.go
+++ b/cmd/go-mutesting/main_test.go
@@ -15,7 +15,7 @@ func TestMain(t *testing.T) {
 		"../../example",
 		[]string{"--debug", "--exec-timeout", "1"},
 		returnOk,
-		"The mutation score is 0.538462 (7 passed, 6 failed, 9 duplicated, 0 skipped, total is 22)",
+		"The mutation score is 0.538462 (7 passed, 6 failed, 9 duplicated, 0 skipped, total is 13)",
 	)
 }
 
@@ -25,7 +25,7 @@ func TestMainRecursive(t *testing.T) {
 		"../../example",
 		[]string{"--debug", "--exec-timeout", "1", "./..."},
 		returnOk,
-		"The mutation score is 0.571429 (8 passed, 6 failed, 9 duplicated, 0 skipped, total is 23)",
+		"The mutation score is 0.571429 (8 passed, 6 failed, 9 duplicated, 0 skipped, total is 14)",
 	)
 }
 
@@ -35,7 +35,7 @@ func TestMainFromOtherDirectory(t *testing.T) {
 		"../..",
 		[]string{"--debug", "--exec-timeout", "1", "github.com/zimmski/go-mutesting/example"},
 		returnOk,
-		"The mutation score is 0.538462 (7 passed, 6 failed, 9 duplicated, 0 skipped, total is 22)",
+		"The mutation score is 0.538462 (7 passed, 6 failed, 9 duplicated, 0 skipped, total is 13)",
 	)
 }
 

--- a/test/mutator.go
+++ b/test/mutator.go
@@ -61,7 +61,10 @@ func Mutator(t *testing.T, m mutator.Mutator, testFile string, count int) {
 		changedFile, err := ioutil.ReadFile(changedFilename)
 		assert.Nil(t, err)
 
-		assert.Equal(t, string(changedFile), buf.String(), fmt.Sprintf("For change file %q", changedFilename))
+		if !assert.Equal(t, string(changedFile), buf.String(), fmt.Sprintf("For change file %q", changedFilename)) {
+			err = ioutil.WriteFile(fmt.Sprintf("%s.%d.go.new", testFile, i), []byte(buf.String()), 0644)
+			assert.Nil(t, err)
+		}
 
 		changed <- true
 


### PR DESCRIPTION
Duplicated mutations should not change the mutation score, and should therefore not counts towards the total count of mutations.