### PR TITLE
Switch to Go 1.7 and 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 
 go:
-  - 1.7.1
+  - 1.7.x
+  - 1.8.x
 
 sudo: false
 


### PR DESCRIPTION
We are only supporting the two latest major Go releases.