### PR TITLE
Support Go 1.10. Fork the part of osutil this package needs, because …

### DIFF
--- a/cmd/go-mutesting/main.go
+++ b/cmd/go-mutesting/main.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/jessevdk/go-flags"
 	"github.com/zimmski/go-tool/importing"
-	"github.com/zimmski/osutil"
 
 	"github.com/zimmski/go-mutesting"
 	"github.com/zimmski/go-mutesting/astutil"
@@ -28,6 +27,7 @@ import (
 	_ "github.com/zimmski/go-mutesting/mutator/branch"
 	_ "github.com/zimmski/go-mutesting/mutator/expression"
 	_ "github.com/zimmski/go-mutesting/mutator/statement"
+	"github.com/zimmski/go-mutesting/osutil"
 )
 
 const (
@@ -133,7 +133,7 @@ func verbose(opts *options, format string, args ...interface{}) {
 }
 
 func exitError(format string, args ...interface{}) int {
-	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	_, _ = fmt.Fprintf(os.Stderr, format+"\n", args...)
 
 	return returnError
 }

--- a/osutil/copy.go
+++ b/osutil/copy.go
@@ -1,0 +1,44 @@
+package osutil
+
+import (
+	"io"
+	"os"
+)
+
+// CopyFile copies a file from src to dst
+// Forked from github.com/zimmski/osutil because that package does not compile on Go 1.10
+func CopyFile(src string, dst string) (err error) {
+	s, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		e := s.Close()
+		if err == nil {
+			err = e
+		}
+	}()
+
+	d, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		e := d.Close()
+		if err == nil {
+			err = e
+		}
+	}()
+
+	_, err = io.Copy(d, s)
+	if err != nil {
+		return err
+	}
+
+	i, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+
+	return os.Chmod(dst, i.Mode())
+}

--- a/osutil/copy_test.go
+++ b/osutil/copy_test.go
@@ -1,0 +1,28 @@
+package osutil
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCopyFile(t *testing.T) {
+	src := "copy.go"
+	dst := "copy.go.tmp"
+
+	err := CopyFile(src, dst)
+	assert.Nil(t, err)
+
+	s, err := ioutil.ReadFile(src)
+	assert.Nil(t, err)
+
+	d, err := ioutil.ReadFile(dst)
+	assert.Nil(t, err)
+
+	assert.Equal(t, s, d)
+
+	err = os.Remove(dst)
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
…it only needs one small function

Fixes https://github.com/zimmski/go-mutesting/issues/60