### PR TITLE
Add comparison expression mutator

### DIFF
--- a/cmd/go-mutesting/main_test.go
+++ b/cmd/go-mutesting/main_test.go
@@ -15,7 +15,7 @@ func TestMain(t *testing.T) {
 		"../../example",
 		[]string{"--debug", "--exec-timeout", "1"},
 		returnOk,
-		"The mutation score is 0.500000 (8 passed, 8 failed, 8 duplicated, 0 skipped, total is 16)",
+		"The mutation score is 0.450000 (9 passed, 11 failed, 8 duplicated, 0 skipped, total is 20)",
 	)
 }
 
@@ -25,7 +25,7 @@ func TestMainRecursive(t *testing.T) {
 		"../../example",
 		[]string{"--debug", "--exec-timeout", "1", "./..."},
 		returnOk,
-		"The mutation score is 0.529412 (9 passed, 8 failed, 8 duplicated, 0 skipped, total is 17)",
+		"The mutation score is 0.476190 (10 passed, 11 failed, 8 duplicated, 0 skipped, total is 21)",
 	)
 }
 
@@ -35,7 +35,7 @@ func TestMainFromOtherDirectory(t *testing.T) {
 		"../..",
 		[]string{"--debug", "--exec-timeout", "1", "github.com/zimmski/go-mutesting/example"},
 		returnOk,
-		"The mutation score is 0.500000 (8 passed, 8 failed, 8 duplicated, 0 skipped, total is 16)",
+		"The mutation score is 0.450000 (9 passed, 11 failed, 8 duplicated, 0 skipped, total is 20)",
 	)
 }
 

--- a/mutator/expression/comparison.go
+++ b/mutator/expression/comparison.go
@@ -1,0 +1,45 @@
+package expression
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+
+	"github.com/zimmski/go-mutesting/mutator"
+)
+
+func init() {
+	mutator.Register("expression/comparison", MutatorComparison)
+}
+
+var comparisonMutations = map[token.Token]token.Token{
+	token.LSS: token.LEQ,
+	token.LEQ: token.LSS,
+	token.GTR: token.GEQ,
+	token.GEQ: token.GTR,
+}
+
+// MutatorComparison implements a mutator to change comparisons.
+func MutatorComparison(pkg *types.Package, info *types.Info, node ast.Node) []mutator.Mutation {
+	n, ok := node.(*ast.BinaryExpr)
+	if !ok {
+		return nil
+	}
+
+	o := n.Op
+	r, ok := comparisonMutations[n.Op]
+	if !ok {
+		return nil
+	}
+
+	return []mutator.Mutation{
+		mutator.Mutation{
+			Change: func() {
+				n.Op = r
+			},
+			Reset: func() {
+				n.Op = o
+			},
+		},
+	}
+}

--- a/mutator/expression/comparison_test.go
+++ b/mutator/expression/comparison_test.go
@@ -1,0 +1,16 @@
+package expression
+
+import (
+	"testing"
+
+	"github.com/zimmski/go-mutesting/test"
+)
+
+func TestMutatorComparison(t *testing.T) {
+	test.Mutator(
+		t,
+		MutatorComparison,
+		"../../testdata/expression/comparison.go",
+		4,
+	)
+}

--- a/testdata/expression/comparison.go
+++ b/testdata/expression/comparison.go
@@ -1,0 +1,27 @@
+// +build example-main
+
+package main
+
+import "fmt"
+
+func main() {
+	if 1 > 2 {
+		fmt.Printf("1 is greater than 2!")
+	}
+
+	if 1 < 2 {
+		fmt.Printf("1 is less than 2!")
+	}
+
+	if 1 <= 2 {
+		fmt.Printf("1 is less than or equal to 2!")
+	}
+
+	if 1 >= 2 {
+		fmt.Printf("1 is greater than or equal to 2!")
+	}
+
+	if 1 == 2 {
+		fmt.Print("1 is equal to 2!")
+	}
+}

--- a/testdata/expression/comparison.go.0.go
+++ b/testdata/expression/comparison.go.0.go
@@ -1,0 +1,27 @@
+// +build example-main
+
+package main
+
+import "fmt"
+
+func main() {
+	if 1 >= 2 {
+		fmt.Printf("1 is greater than 2!")
+	}
+
+	if 1 < 2 {
+		fmt.Printf("1 is less than 2!")
+	}
+
+	if 1 <= 2 {
+		fmt.Printf("1 is less than or equal to 2!")
+	}
+
+	if 1 >= 2 {
+		fmt.Printf("1 is greater than or equal to 2!")
+	}
+
+	if 1 == 2 {
+		fmt.Print("1 is equal to 2!")
+	}
+}

--- a/testdata/expression/comparison.go.1.go
+++ b/testdata/expression/comparison.go.1.go
@@ -1,0 +1,27 @@
+// +build example-main
+
+package main
+
+import "fmt"
+
+func main() {
+	if 1 > 2 {
+		fmt.Printf("1 is greater than 2!")
+	}
+
+	if 1 <= 2 {
+		fmt.Printf("1 is less than 2!")
+	}
+
+	if 1 <= 2 {
+		fmt.Printf("1 is less than or equal to 2!")
+	}
+
+	if 1 >= 2 {
+		fmt.Printf("1 is greater than or equal to 2!")
+	}
+
+	if 1 == 2 {
+		fmt.Print("1 is equal to 2!")
+	}
+}

--- a/testdata/expression/comparison.go.2.go
+++ b/testdata/expression/comparison.go.2.go
@@ -1,0 +1,27 @@
+// +build example-main
+
+package main
+
+import "fmt"
+
+func main() {
+	if 1 > 2 {
+		fmt.Printf("1 is greater than 2!")
+	}
+
+	if 1 < 2 {
+		fmt.Printf("1 is less than 2!")
+	}
+
+	if 1 < 2 {
+		fmt.Printf("1 is less than or equal to 2!")
+	}
+
+	if 1 >= 2 {
+		fmt.Printf("1 is greater than or equal to 2!")
+	}
+
+	if 1 == 2 {
+		fmt.Print("1 is equal to 2!")
+	}
+}

--- a/testdata/expression/comparison.go.3.go
+++ b/testdata/expression/comparison.go.3.go
@@ -1,0 +1,27 @@
+// +build example-main
+
+package main
+
+import "fmt"
+
+func main() {
+	if 1 > 2 {
+		fmt.Printf("1 is greater than 2!")
+	}
+
+	if 1 < 2 {
+		fmt.Printf("1 is less than 2!")
+	}
+
+	if 1 <= 2 {
+		fmt.Printf("1 is less than or equal to 2!")
+	}
+
+	if 1 > 2 {
+		fmt.Printf("1 is greater than or equal to 2!")
+	}
+
+	if 1 == 2 {
+		fmt.Print("1 is equal to 2!")
+	}
+}


### PR DESCRIPTION
This PR adds a comparison expression mutator which generates mutations with every other type of comparison.

~~I noticed something odd with this - it seems to have caused the number of failures to drop for some tests? I don't quite understand this, as the tests would still surely fail (i.e. the mutants would escape) for the previous mutations, but some new tests are being generated too. I'd expect that the number of failures would stay the same or go up, as if a test passes when removing an expression but fails when changing the comparison then a mutant has still escaped (and the failed count should increase).~~

~~You can see the changes I had to make in a7d34c1.~~

Turns out I had run `go-mutesting` on `go-mutesting` itself and CTRL-C'd half way through, which left me with some mutated source files! I still had to update the tests but the numbers look a lot better now. See cc978965e63c9869d453b89b030a7be37151c14a for the updated commit.

This PR fixes #23.