### PR TITLE
Add --score flag to set a minimal acceptance

### DIFF
--- a/cmd/go-mutesting/main_test.go
+++ b/cmd/go-mutesting/main_test.go
@@ -49,6 +49,16 @@ func TestMainMatch(t *testing.T) {
 	)
 }
 
+func TestMainScore(t *testing.T) {
+	testMain(
+		t,
+		"../../example",
+		[]string{"--debug", "--exec-timeout", "1", "--score", "0.46"},
+		returnError,
+		"The mutation score is 0.450000 (9 passed, 11 failed, 8 duplicated, 0 skipped, total is 20)",
+	)
+}
+
 func testMain(t *testing.T, root string, exec []string, expectedExitCode int, contains string) {
 	saveStderr := os.Stderr
 	saveStdout := os.Stdout


### PR DESCRIPTION
Hello. Thank you for a great tool!

I like your library a lot and started to use it in my projects. Although, it's difficult to use it in CI without non-zero exit codes if the scores are non-acceptable.

Here's my attempt to implement the way to achieve both purposes at once.