### PR TITLE
Enable Providing Build Tags For Tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ export ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 export PKG := github.com/zimmski/go-mutesting
 export ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
-export TEST_TIMEOUT_IN_SECONDS := 240
+export TEST_TIMEOUT_IN_SECONDS := 360
 
 $(eval $(ARGS):;@:) # turn arguments into do-nothing targets
 export ARGS

--- a/cmd/go-mutesting/main.go
+++ b/cmd/go-mutesting/main.go
@@ -39,10 +39,11 @@ const (
 
 type options struct {
 	General struct {
-		Debug                bool `long:"debug" description:"Debug log output"`
-		DoNotRemoveTmpFolder bool `long:"do-not-remove-tmp-folder" description:"Do not remove the tmp folder where all mutations are saved to"`
-		Help                 bool `long:"help" description:"Show this help message"`
-		Verbose              bool `long:"verbose" description:"Verbose log output"`
+		Debug                bool   `long:"debug" description:"Debug log output"`
+		DoNotRemoveTmpFolder bool   `long:"do-not-remove-tmp-folder" description:"Do not remove the tmp folder where all mutations are saved to"`
+		Help                 bool   `long:"help" description:"Show this help message"`
+		Verbose              bool   `long:"verbose" description:"Verbose log output"`
+		TestTags             string `long:"test-tags" description:"Build tags used when running go test"`
 	} `group:"General options"`
 
 	Files struct {
@@ -407,7 +408,13 @@ func mutateExec(opts *options, pkg *types.Package, file string, src ast.Node, mu
 			pkgName += "/..."
 		}
 
-		test, err := exec.Command("go", "test", "-timeout", fmt.Sprintf("%ds", opts.Exec.Timeout), pkgName).CombinedOutput()
+		var test []byte
+		if opts.General.TestTags != "" {
+			test, err = exec.Command("go", "test", "-tags", opts.General.TestTags, "-timeout", fmt.Sprintf("%ds", opts.Exec.Timeout), pkgName).CombinedOutput()
+		} else {
+			test, err = exec.Command("go", "test", "-timeout", fmt.Sprintf("%ds", opts.Exec.Timeout), pkgName).CombinedOutput()
+		}
+
 		if err == nil {
 			execExitCode = 0
 		} else if e, ok := err.(*exec.ExitError); ok {

--- a/cmd/go-mutesting/main_test.go
+++ b/cmd/go-mutesting/main_test.go
@@ -15,7 +15,7 @@ func TestMain(t *testing.T) {
 		"../../example",
 		[]string{"--debug", "--exec-timeout", "1"},
 		returnOk,
-		"The mutation score is 0.450000 (9 passed, 11 failed, 8 duplicated, 0 skipped, total is 20)",
+		"The mutation score is 0.428571 (9 passed, 12 failed, 8 duplicated, 0 skipped, total is 21)",
 	)
 }
 
@@ -25,7 +25,7 @@ func TestMainRecursive(t *testing.T) {
 		"../../example",
 		[]string{"--debug", "--exec-timeout", "1", "./..."},
 		returnOk,
-		"The mutation score is 0.476190 (10 passed, 11 failed, 8 duplicated, 0 skipped, total is 21)",
+		"The mutation score is 0.454545 (10 passed, 12 failed, 8 duplicated, 0 skipped, total is 22)",
 	)
 }
 
@@ -35,7 +35,7 @@ func TestMainFromOtherDirectory(t *testing.T) {
 		"../..",
 		[]string{"--debug", "--exec-timeout", "1", "github.com/zimmski/go-mutesting/example"},
 		returnOk,
-		"The mutation score is 0.450000 (9 passed, 11 failed, 8 duplicated, 0 skipped, total is 20)",
+		"The mutation score is 0.428571 (9 passed, 12 failed, 8 duplicated, 0 skipped, total is 21)",
 	)
 }
 
@@ -46,6 +46,16 @@ func TestMainMatch(t *testing.T) {
 		[]string{"--debug", "--exec", "../scripts/exec/test-mutated-package.sh", "--exec-timeout", "1", "--match", "baz", "./..."},
 		returnOk,
 		"The mutation score is 0.500000 (1 passed, 1 failed, 0 duplicated, 0 skipped, total is 2)",
+	)
+}
+
+func TestTagged(t *testing.T) {
+	testMain(
+		t,
+		"../../example",
+		[]string{"--debug", "--exec-timeout", "1", "--test-tags", "tagged", "github.com/zimmski/go-mutesting/example"},
+		returnOk,
+		"The mutation score is 0.476190 (10 passed, 11 failed, 8 duplicated, 0 skipped, total is 21)",
 	)
 }
 

--- a/example/tagged.go
+++ b/example/tagged.go
@@ -1,0 +1,5 @@
+package example
+
+func gt(a, b int) bool {
+	return a > b
+}

--- a/example/tagged_test.go
+++ b/example/tagged_test.go
@@ -1,0 +1,21 @@
+// +build tagged
+
+package example
+
+import (
+	"testing"
+
+	. "github.com/stretchr/testify/assert"
+)
+
+func TestGreaterThan(t *testing.T) {
+	Equal(t, gt(2,1), true)
+}
+
+func TestLessThan(t *testing.T) {
+	Equal(t, gt(1,2), false)
+}
+
+func TestEqual(t *testing.T) {
+	Equal(t, gt(2,2), false)
+}


### PR DESCRIPTION
adding the `--test-tags` flag.
The value of `--test-tags` is given to `-tags` when running `go test` to check mutations.

Closes #87