### PR TITLE
Remove skipped tests from total score

### DIFF
--- a/cmd/go-mutesting/main.go
+++ b/cmd/go-mutesting/main.go
@@ -155,7 +155,7 @@ func (ms *mutationStats) Score() float64 {
 }
 
 func (ms *mutationStats) Total() int {
-	return ms.passed + ms.failed + ms.skipped
+	return ms.passed + ms.failed
 }
 
 func mainCmd(args []string) int {


### PR DESCRIPTION
In order to maintain consistency in output results, skipped tests are removed from final total score. Skipped tests are still visible on result details, but final score will be calculated based only in passed and failed tests.

Fixes #89 